### PR TITLE
Fix programatically toggle switch

### DIFF
--- a/src/AlohaKit/Controls/ToggleSwitch/ToggleSwitch.cs
+++ b/src/AlohaKit/Controls/ToggleSwitch/ToggleSwitch.cs
@@ -53,7 +53,7 @@ namespace AlohaKit.Controls
         }
 
         public static readonly BindableProperty IsOnProperty =
-           BindableProperty.Create(nameof(IsOn), typeof(bool), typeof(ToggleSwitch), false,
+           BindableProperty.Create(nameof(IsOn), typeof(bool), typeof(ToggleSwitch), false, defaultBindingMode: BindingMode.TwoWay,
                propertyChanged: (bindableObject, oldValue, newValue) =>
                {
                    if (newValue != null && bindableObject is ToggleSwitch toggleSwitch)


### PR DESCRIPTION
I still encounter this problem (https://github.com/jsuarezruiz/AlohaKit.Controls/issues/48) on the ToggleSwitch. By making  `defaultBindingMode: BindingMode.TwoWay` fix it for this use-case